### PR TITLE
Fix `nvm_shell_init: false` not working

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -22,6 +22,9 @@
   args:
     chdir: "{{ nvm_tmp_path }}"
   changed_when: true
+  environment:
+    # disable built-in functionality to update the shell init scripts, as we have that functionality in this role
+    PROFILE: /dev/null
 
 - name: Delete NVM installation temp
   file:


### PR DESCRIPTION
The nvm installer duplicates that functionality now, so let's disable it on that end so users with `nvm_shell_init: false` will get the desired behavior.

Alternative approach would be to remove that functionality on this end, but that would require a breaking change, as this project supports initializing multiple init scripts while the nvm installer only support passing in one via the PROFILE env var.

Fixes #15.

## Testing

Included this branch in my ansible project like this:
```yml
# requirements.yml
---
roles:
  - name: markosamuli.nvm
    # workaround until https://github.com/markosamuli/ansible-nvm/pull/16 is merged:
    src: https://github.com/sargunv/ansible-nvm
    version: patch-1
```

and configured my role as normal:
```yml
- ansible.builtin.include_role:
    name: markosamuli.nvm
  vars:
    nvm_default_node_version: lts/*
    nvm_node_versions:
      - "{{ nvm_default_node_version }}"
    nvm_shell_init: False
    nvm_version: v0.39.1
    # curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/VERSION/install.sh | sha256sum | cut -d' ' -f1
    nvm_install_checksum: "sha256:fabc489b39a5e9c999c7cab4d281cdbbcbad10ec2f8b9a7f7144ad701b6bfdc7"
```

and I no longer get the lines appended to my ~/.zshrc.