### PR TITLE
fix: respect nvm_dir for nvm install.sh script

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -17,8 +17,16 @@
     path: "{{ nvm_tmp_path }}/install.sh"
     mode: 0755
 
+- name: Ensure NVM installation path exists
+  ansible.builtin.file:
+    path: "{{ nvm_dir }}"
+    state: directory
+    mode: 0755
+
 - name: Run NVM installation script
   command: "bash {{ nvm_tmp_path }}/install.sh"
+  environment:
+    NVM_DIR: "{{ nvm_dir }}"
   args:
     chdir: "{{ nvm_tmp_path }}"
   changed_when: true

--- a/tasks/versions.yml
+++ b/tasks/versions.yml
@@ -3,7 +3,7 @@
 - name: Install default Node.js versions with NVM
   environment:
     NVM_DIR: "{{ nvm_dir }}"
-  shell: "source {{ nvm_dir }}/nvm.sh && nvm install {{ item }}"
+  shell: "source {{ nvm_dir }}/nvm.sh --no-use && nvm install {{ item }}"
   args:
     executable: /bin/bash
   with_items: "{{ nvm_node_versions }}"


### PR DESCRIPTION
### tasks/install.yml
The NVM `install.sh` script needs this environment variable in order to pick a different path than `$HOME/.config/nvm`

### tasks/versions.yml
`--no-use` fixes issues with nvm complaining that a version is needed in the case of previous installations